### PR TITLE
Allow configuring priority class in helm chart

### DIFF
--- a/chart/templates/deployment.yml
+++ b/chart/templates/deployment.yml
@@ -89,6 +89,9 @@ spec:
               name: cert
               readOnly: true
       terminationGracePeriodSeconds: 10
+      {{- if .Values.manager.priorityClassName }}
+      priorityClassName: {{ .Values.manager.priorityClassName }}
+      {{- end }}
       volumes:
         - name: cert
           secret:


### PR DESCRIPTION
@kyma-incubator/sre reported missing priority class for btp-operator which may result in delays and complications to deploy kyma on resource-constrained environments.

> During kyma upgade we have faced a **btp-operator** component was in **reconciliation_stuck_error** state.
The reason is that the corresponding pod was in **Pending** state due to **insufficient cpu**.
kyma-system namespace component should have priority when it comes to resource allocation.
Due to missing **PriorityClassName** attribute in btp-operator, this component was **starving** from customer components.

This enables configuring `priorityClassName` in the helm chart, KEB can then pass the desired class name.