### PR TITLE
Version 0.3.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.2.5
+appVersion: v0.3.0
 description: A Helm chart for SAP BTP Operator for Kubernetes
 name: sap-btp-operator
-version: v0.2.5
+version: v0.3.0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -14,7 +14,7 @@ manager:
   management_namespace:
   image:
     repository: ghcr.io/sap/sap-btp-service-operator/controller
-    tag: v0.2.5
+    tag: v0.3.0
   secret:
     b64encoded: false
     enabled: true


### PR DESCRIPTION
Bump BTP operator to 0.3.0

There was no significant chart changes, so only bump is needed.